### PR TITLE
Fix section titles on people page

### DIFF
--- a/people.md
+++ b/people.md
@@ -1,6 +1,4 @@
-# Steering Council, Advisory Board and Institutional Partners
-
-## Steering Council
+# Steering Council
 
 - Francesco Ballarin (Università Cattolica del Sacro Cuore)
 - Cécile Daversin-Catty (Simula Research Laboratory)
@@ -12,7 +10,12 @@
 - Nathan (Nate) Sime (Carnegie Institution for Science)
 - Garth N. Wells (University of Cambridge)
 
-### Retired council members
+## NumFOCUS Subcommittee
+
+- Jack S. Hale
+- Chris Richardson
+
+## Former Steering Council members
 
 - 2016-2024 Marie E. Rognes (Simula Research Laboratory)
 - 2016-2023 Johannes Ring (Simula Research Laboratory)
@@ -20,16 +23,10 @@
 - 2016-2018 Jan Blechta (Charles University, Chemnitz University of Technology)
 - 2016-2018 Martin S. Alnæs (Simula Research Laboratory)
 
-### NumFOCUS Subcommittee
-
-- Jack S. Hale
-- Chris Richardson
-
 ## New Steering Council Members
 
 When a new Member joins the Steering Council, the following steps
 should be taken:
-
 - Announce the new member on the FEniCS Project Slack.
 - Add the new Member to the list in the governance repo, and if
   appropriate, add their affiliation to the Institutional Partner list.


### PR DESCRIPTION
Page referred to institutional members and advisory board, which have earlier been removed.